### PR TITLE
Bump sqlite-jdbc to 3.42.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation "org.slf4j:slf4j-api:1.7.36"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     api "org.springframework.data:spring-data-jdbc:2.4.5"
-    implementation 'org.xerial:sqlite-jdbc:3.40.0.0'
+    implementation 'org.xerial:sqlite-jdbc:3.42.0.1'
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.8.2"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.8.2"
     testImplementation "org.assertj:assertj-core:3.22.0"


### PR DESCRIPTION
Not to `3.43.0` or later since https://github.com/xerial/sqlite-jdbc/issues/329 broke something.