### PR TITLE
Revert "Bump version to 1.3.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id "com.diffplug.spotless" version "6.24.0"
 }
 
-project.version = '1.3.0'
+project.version = '1.2.0'
 group = "org.komamitsu"
 
 repositories {


### PR DESCRIPTION
Reverts komamitsu/spring-data-sqlite#19

v1.2 isn't released yet.